### PR TITLE
fix: Restrict access to webhook_event_logs table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5509,6 +5509,7 @@
       "version": "17.2.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
       "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/supabase/migrations/20250814081800_create_and_secure_webhook_event_logs.sql
+++ b/supabase/migrations/20250814081800_create_and_secure_webhook_event_logs.sql
@@ -1,0 +1,42 @@
+-- Create the webhook_event_logs table if it doesn't exist
+CREATE TABLE IF NOT EXISTS public.webhook_event_logs (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  payload JSONB,
+  status TEXT,
+  error_message TEXT
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.webhook_event_logs ENABLE ROW LEVEL SECURITY;
+
+-- Remove public access
+REVOKE ALL ON TABLE public.webhook_event_logs FROM public;
+REVOKE ALL ON TABLE public.webhook_event_logs FROM authenticated;
+REVOKE ALL ON TABLE public.webhook_event_logs FROM anon;
+
+-- Grant access to service_role
+GRANT ALL ON TABLE public.webhook_event_logs TO service_role;
+
+-- Create a policy to allow service role to access all logs
+CREATE POLICY "Allow service role to access all logs"
+ON public.webhook_event_logs
+FOR ALL
+TO service_role
+USING (true);
+
+-- Create a policy to allow only 'medico' users (administrators) to view the logs
+CREATE POLICY "Allow administrators to view integration logs"
+ON public.webhook_event_logs
+FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles
+    WHERE id = auth.uid() AND user_type = 'medico'
+  )
+);
+
+-- Add a comment to the new policy for clarity
+COMMENT ON POLICY "Allow administrators to view integration logs" ON public.webhook_event_logs
+IS 'Only users with the medico user_type can view webhook event logs.';


### PR DESCRIPTION
This commit addresses a security vulnerability where the `webhook_event_logs` table had public read and write access.

A new Supabase migration is introduced to:
1.  Create the `webhook_event_logs` table if it doesn't exist.
2.  Enable Row-Level Security (RLS) on the table.
3.  Revoke all access from public, authenticated, and anonymous roles.
4.  Grant full access to the `service_role`.
5.  Add a policy to allow users with the `medico` user_type (administrators) to have read-only access to the logs.

This change ensures that sensitive webhook data is protected and only accessible by authorized roles.