### PR TITLE
Fix(monitoring): Remove payments check from system health check

### DIFF
--- a/supabase/migrations/20250815215015_21345922-bbbd-4e75-95e8-3c9e3d8b78a7.sql
+++ b/supabase/migrations/20250815215015_21345922-bbbd-4e75-95e8-3c9e3d8b78a7.sql
@@ -151,18 +151,15 @@ DECLARE
   auth_users_count integer;
   profiles_count integer;
   consultas_today integer;
-  pagamentos_today integer;
 BEGIN
   -- Verificar contadores básicos
   SELECT COUNT(*) INTO profiles_count FROM public.profiles WHERE is_active = true;
   SELECT COUNT(*) INTO consultas_today FROM public.consultas WHERE DATE(created_at) = CURRENT_DATE;
-  SELECT COUNT(*) INTO pagamentos_today FROM public.pagamentos WHERE DATE(created_at) = CURRENT_DATE;
 
   -- Retornar status dos componentes
   RETURN QUERY VALUES
     ('database'::text, 'healthy'::text, jsonb_build_object('profiles', profiles_count)::jsonb, now()::timestamptz),
-    ('appointments'::text, 'healthy'::text, jsonb_build_object('today', consultas_today)::jsonb, now()::timestamptz),
-    ('payments'::text, 'healthy'::text, jsonb_build_object('today', pagamentos_today)::jsonb, now()::timestamptz);
+    ('appointments'::text, 'healthy'::text, jsonb_build_object('today', consultas_today)::jsonb, now()::timestamptz);
 END;
 $function$;
 


### PR DESCRIPTION
The system health check function (`system_health_check`) was querying a `pagamentos` table that does not exist in the database schema. This caused the function to fail and triggered a "monitoring error" in the frontend.

This commit removes the logic related to the `pagamentos` table from the `system_health_check` function to resolve the error.