### PR TITLE
feat: Adicionar políticas de RLS para a tabela pagamentos

### DIFF
--- a/supabase/migrations/20250819211700_add_rls_to_pagamentos.sql
+++ b/supabase/migrations/20250819211700_add_rls_to_pagamentos.sql
@@ -1,0 +1,36 @@
+-- Adicionar políticas de RLS para a tabela de pagamentos
+
+-- Habilitar RLS na tabela de pagamentos
+ALTER TABLE public.pagamentos ENABLE ROW LEVEL SECURITY;
+
+-- Remover políticas antigas se existirem, para garantir um estado limpo
+DROP POLICY IF EXISTS "policy_select_pagamentos" ON public.pagamentos;
+DROP POLICY IF EXISTS "policy_all_pagamentos_service_role" ON public.pagamentos;
+
+-- Política de SELECT: Pacientes e médicos podem ver os pagamentos das suas consultas
+CREATE POLICY "policy_select_pagamentos"
+ON public.pagamentos
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.consultas
+    WHERE consultas.id = pagamentos.consulta_id
+    AND (
+      consultas.paciente_id = auth.uid() OR
+      consultas.medico_id = auth.uid()
+    )
+  )
+);
+
+-- Política de Acesso Total para service_role: Permite que o backend gerencie os pagamentos
+CREATE POLICY "policy_all_pagamentos_service_role"
+ON public.pagamentos
+FOR ALL
+TO service_role
+USING (true);
+
+-- Comentários para documentação
+COMMENT ON POLICY "policy_select_pagamentos" ON public.pagamentos IS 'Pacientes e médicos podem visualizar os pagamentos associados às suas próprias consultas.';
+COMMENT ON POLICY "policy_all_pagamentos_service_role" ON public.pagamentos IS 'Permite que o backend (service_role) tenha acesso total para gerenciar todos os pagamentos.';


### PR DESCRIPTION
Cria um novo arquivo de migração para habilitar o Row-Level Security (RLS) e definir políticas de acesso para a tabela `pagamentos`.

As políticas implementadas garantem que:
- Usuários autenticados (pacientes e médicos) só podem visualizar os pagamentos associados às suas próprias consultas.
- A `service_role` (utilizada pelo backend) tem acesso total para operações administrativas.

Esta alteração aumenta a segurança e a privacidade dos dados financeiros na plataforma, conforme solicitado.

Tarefas ignoradas:
- A configuração de OTP e proteção de senha foi ignorada porque o arquivo `supabase/config.toml` não continha as chaves esperadas.
- A adição de `SET search_path` às funções foi ignorada porque as funções listadas na documentação não foram encontradas no código.
- A execução dos testes e2e não foi possível devido a erros persistentes no ambiente de teste.