### PR TITLE
fix(agendamento): Correct ReferenceError in temporary reservation

### DIFF
--- a/src/hooks/useAdvancedScheduling.ts
+++ b/src/hooks/useAdvancedScheduling.ts
@@ -92,7 +92,7 @@ export const useAdvancedScheduling = () => {
 
       // Set cleanup timer
       const timer = setTimeout(() => {
-        cleanupTemporaryReservation(sessionId);
+        cleanupTemporaryReservation(result.sessionId);
       }, 15 * 60 * 1000);
 
       setReservationTimer(timer);


### PR DESCRIPTION
This commit fixes a critical bug in the appointment scheduling flow that caused a crash in Step 6 (Time Selection).

During a previous refactoring, a call to `cleanupTemporaryReservation` was left with a reference to a `sessionId` variable that no longer existed in its scope. This resulted in a `ReferenceError`.

The fix updates the call to use `result.sessionId`, which is the correct variable available from the service proxy's return value. This resolves the crash and allows the scheduling flow to proceed correctly when using mock services.